### PR TITLE
Fix an extra whitespace before paren in function call causing ruby to complain.

### DIFF
--- a/lib/rally_api/rally_rest_json.rb
+++ b/lib/rally_api/rally_rest_json.rb
@@ -434,7 +434,7 @@ module RallyAPI
     def self.camel_case_word(sym)
       word = sym.to_s
 
-      if word.start_with? ("c_")
+      if word.start_with?("c_")
         custom_field_without_c = word.sub("c_", "")
         camelized = camelize(custom_field_without_c)
         camelized[0] = custom_field_without_c[0]


### PR DESCRIPTION
Title says it all.
