### PR TITLE
Fix a simple syntax error.

### DIFF
--- a/lib/rally_api/rally_object.rb
+++ b/lib/rally_api/rally_object.rb
@@ -63,7 +63,7 @@ module RallyAPI
 
     def elements
       @rally_object.inject({}) do |elements, (key, value)|
-        if key.to_s.starts_with?("c_")
+        if key.to_s.start_with?("c_")
           key = key.to_s[2..-1]
         end
         elements[underscore(key).to_sym] = value


### PR DESCRIPTION
This fixes a simple syntax error preventing `RallyObject#elements` from functioning.

See the [documentation](http://rubydoc.info/stdlib/core/1.8.7/String#start_with%3F-instance_method) for `String#start_with?` for reference.
