### PR TITLE
Quick Fix for WebLink fields

### DIFF
--- a/lib/rally_api/rally_object.rb
+++ b/lib/rally_api/rally_object.rb
@@ -14,7 +14,12 @@ module RallyAPI
     attr_reader :rally_object, :type, :warnings
 
     def initialize(rally_rest, json_hash, warnings = {})
-      @type = json_hash["_type"] || json_hash["_ref"].split("/")[-2]
+      # handle that we might not get a _ref or a _type
+      if !json_hash["_type"].nil? || !json_hash["_ref"].nil?
+        @type = json_hash["_type"] || json_hash["_ref"].split("/")[-2]
+      else
+        @type = "unknown"
+      end
       @rally_object = json_hash
       @rally_rest = rally_rest
       @warnings = warnings[:warnings]

--- a/test/rally_api_create_spec.rb
+++ b/test/rally_api_create_spec.rb
@@ -37,6 +37,21 @@ describe "Rally Json Create Tests" do
     new_de.Name.should == obj["Name"]
     new_de.Owner["_ref"].should == @rally.user["_ref"]
   end
+  
+  it "should create with a web link field" do
+    weblink_field_name = RallyAPISpecHelper::EXTRA_SETUP[:weblink_field_name]
+    if !weblink_field_name.nil?
+      obj = {}
+      obj["Name"] = "Test with a weblink"
+      obj[weblink_field_name] = {
+        "LinkID"=>"123", "DisplayString"=>"The Label"
+      }
+      new_de = @rally.create(:defect, setup_test_defect(obj))
+      new_de.Name.should == obj["Name"]
+      new_de[weblink_field_name]["LinkID"].should == "123"
+      new_de[weblink_field_name]["DisplayString"].should == "The Label"
+    end
+  end
 
   it "should raise an error on create if a field is required" do
     obj = {}

--- a/test/rally_api_spec_helper.rb
+++ b/test/rally_api_spec_helper.rb
@@ -25,6 +25,7 @@ require_relative "../lib/rally_api"
 #Debug:     false
 #NonDefaultWS:  NonDefaultWorkspace
 #CustomPIType:  CustomType
+#WebLinkFieldName: CustomField
 
 module RallyAPISpecHelper
   path = ""
@@ -50,4 +51,5 @@ module RallyAPISpecHelper
   EXTRA_SETUP = {}
   EXTRA_SETUP[:nondefault_ws]  = config["NonDefaultWS"]
   EXTRA_SETUP[:custom_pi_type] = config["CustomPIType"]
+  EXTRA_SETUP[:weblink_field_name] = config["WebLinkFieldName"]
 end


### PR DESCRIPTION
No error checking, just passing a hash and getting a hash back.  The problem is that the WebLink comes back as a hash but it doesn't have a _ref or _type to it has to be converted to something to be used.
