### PR TITLE
Switch default WSAPI version to "v2.0"

### DIFF
--- a/lib/rally_api/rally_rest_json.rb
+++ b/lib/rally_api/rally_rest_json.rb
@@ -44,7 +44,7 @@ module RallyAPI
 
   #Main Class to instantiate when using the tool
   class RallyRestJson
-    DEFAULT_WSAPI_VERSION = "1.42"
+    DEFAULT_WSAPI_VERSION = "v2.0"
 
     attr_accessor :rally_url, :rally_user, :rally_password, :rally_workspace_name, :rally_project_name, :wsapi_version,
                   :rally_headers, :rally_default_workspace, :rally_default_project, :low_debug, :proxy_info,


### PR DESCRIPTION
1.4.2 is deprecated & will be unsupported May 2014. I wasn't sure how to run your specs so I hadn't done it, but my initial testing shows it works for basic queries.

Note that they've added "v" prefix on version number in URL.