### PR TITLE
DE22621- relax httpclient to accept versions greater than or equal to 2.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,3 +151,6 @@ A Rally API Key can be used for user authentication. If an API Key is provided, 
       of allowed values from a user's non-default workspace. Updates gem development dependencies and 
       test files structure.
 
+    Version 1.1.1 (October 2014) - Relax version requirement of httpclient runtime 
+      dependency to '>= 2.3.0'.
+

--- a/lib/rally_api/version.rb
+++ b/lib/rally_api/version.rb
@@ -4,5 +4,5 @@
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.
 module RallyAPI
-  VERSION = "1.1.0"
+  VERSION = "1.1.1"
 end

--- a/rally_api.gemspec
+++ b/rally_api.gemspec
@@ -5,8 +5,8 @@ require "rally_api/version"
 Gem::Specification.new do |s|
   s.name        = "rally_api"
   s.version     = RallyAPI::VERSION
-  s.authors     = ["Dave Smith"]
-  s.email       = ["dsmith@rallydev.com"]
+  s.authors     = ["Dave Smith", "Rylee Keys-DuMars"]
+  s.email       = ["dsmith@rallydev.com", "rylee@rallydev.com"]
   s.homepage    = "https://github.com/RallyTools/RallyRestToolkitForRuby"
   s.summary     = "A wrapper for the Rally Web Services API using json"
   s.description = "API wrapper for Rally's JSON REST web services api"
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = false
 
-  s.add_dependency('httpclient', '~> 2.4.0')
+  s.add_dependency('httpclient', '>= 2.3.0')
   s.add_development_dependency('simplecov', '0.9.1')
   s.add_development_dependency('rspec', '3.1.0')
   s.add_development_dependency('rake', '10.3.2')


### PR DESCRIPTION
Relaxing version restriction of httpclient runtime dependency to allow both versions 2.3.0 and 2.4.0
