### PR TITLE
made default WSAPI_VERSION 2.0, fixed reread to use start instead of sta...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## License
 
-Copyright (c) Rally Software Development Corp. 2013 Distributed under the MIT License.
+Copyright (c) Rally Software Development Corp. 2015 Distributed under the MIT License.
 
 ## Warranty
 
@@ -16,7 +16,7 @@ RallyAPI (rally_api) -- a wrapper for Rally's REST Web Services API
 
 [![Stories in Ready](http://badge.waffle.io/RallyTools/RallyRestToolkitForRuby.png)](http://waffle.io/RallyTools/RallyRestToolkitForRuby)
 
-RallyAPI is a wrapper of Rally's Web Service API Json endpoints using rest-client and native json parsing
+RallyAPI is a wrapper of Rally's Web Service API JSON endpoints using rest-client and native json parsing
 Check the examples directory for more detailed samples.
 
 ### Installation
@@ -70,8 +70,8 @@ A Rally API Key can be used for user authentication. If an API Key is provided, 
     test_query = RallyAPI::RallyQuery.new()
     test_query.type = "defect"
     test_query.fetch = "Name"
-    test_query.workspace = {"_ref" => "https://rally1.rallydev.com/slm/webservice/1.25/workspace/12345.js" } #optional
-    test_query.project = {"_ref" => "https://rally1.rallydev.com/slm/webservice/1.25/project/12345.js" }     #optional
+    test_query.workspace = {"_ref" => "https://rally1.rallydev.com/slm/webservice/v2.0/workspace/12345" } #optional
+    test_query.project = {"_ref" => "https://rally1.rallydev.com/slm/webservice/v2.0/project/12345" }     #optional
     test_query.page_size = 200       #optional - default is 200
     test_query.limit = 1000          #optional - default is 99999
     test_query.project_scope_up = false
@@ -114,8 +114,8 @@ A Rally API Key can be used for user authentication. If an API Key is provided, 
     #If you query with a specific fetch string, for example query defect and fetch Name,Severity,Description
     #You will *only* get back those fields defect.Priority will be nil, but may not be null in Rally
     #Use object.read or @rally.read to make sure you read the whole object if you want what is in Rally
-    #  This is done for speed - lazy loading (going back to get a value from Rally) can be unneccessarily slow
-    #  *Pick you fetch strings wisely* fetch everything you need and don't rely on read if you don't need it the speed is worth it.
+    #  This is done for speed - lazy loading (going back to get a value from Rally) can be unnecessarily slow
+    #  *Pick your fetch strings wisely* fetch everything you need and don't rely on read if you don't need it, the speed is worth it.
 
 ### Creating an Artifact
     obj = {}
@@ -147,12 +147,16 @@ A Rally API Key can be used for user authentication. If an API Key is provided, 
     story1.rank_to_top
 
 ### Revision History
+
+    Version 1.2.0 (April 2015) - set default WSAPI version to 2.0, fix paging issue in reread,
+      can now use DisplayName for custom fields in create and update operations.
+      Set httpclient gem runtime dependency to '= 2.5.0'.
+
+    Version 1.1.2 (October 2014) - Set httpclient gem runtime dependency to '~> 2.4.0'.
+
+    Version 1.1.1 (October 2014) - Relax httpclient gem runtime dependency to '>= 2.3.0'.
+
     Version 1.1.0 (September 2014) - Appends workspace to Rally API requests to enable correct retrieval
       of allowed values from a user's non-default workspace. Updates gem development dependencies and 
       test files structure.
 
-    Version 1.1.1 (October 2014) - Relax version requirement of httpclient runtime 
-      dependency to '>= 2.3.0'.
-
-    Version 1.1.2 (October 2014) - Change version requirement of httpclient runtime 
-      dependency to '~> 2.4.0'.

--- a/lib/rally_api.rb
+++ b/lib/rally_api.rb
@@ -1,4 +1,4 @@
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.

--- a/lib/rally_api/custom_http_header.rb
+++ b/lib/rally_api/custom_http_header.rb
@@ -1,4 +1,4 @@
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.

--- a/lib/rally_api/lookback_api_query.rb
+++ b/lib/rally_api/lookback_api_query.rb
@@ -1,5 +1,5 @@
 # :stopdoc:
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.

--- a/lib/rally_api/rally_collection.rb
+++ b/lib/rally_api/rally_collection.rb
@@ -1,5 +1,5 @@
 # :stopdoc:
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.

--- a/lib/rally_api/rally_json_connection.rb
+++ b/lib/rally_api/rally_json_connection.rb
@@ -2,7 +2,7 @@ require "httpclient"
 require 'json'
 
 # :stopdoc:
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.

--- a/lib/rally_api/rally_object.rb
+++ b/lib/rally_api/rally_object.rb
@@ -1,5 +1,5 @@
 # :stopdoc:
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.
@@ -15,14 +15,15 @@ module RallyAPI
 
     def initialize(rally_rest, json_hash, warnings = {})
       # handle that we might not get a _ref or a _type
-      if !json_hash["_type"].nil? || !json_hash["_ref"].nil?
-        @type = json_hash["_type"] || json_hash["_ref"].split("/")[-2]
-      else
-        @type = "unknown"
-      end
+     @type = "unknown"
+     if json_hash["_type"] && !json_hash["_type"].empty?
+       @type = json_hash["_type"]
+     elsif json_hash["_ref"] && !json_hash["_ref"].empty?
+       @type = json_hash["_ref"].split("/")[-2]
+     end
       @rally_object = json_hash
-      @rally_rest = rally_rest
-      @warnings = warnings[:warnings]
+      @rally_rest   = rally_rest
+      @warnings     = warnings[:warnings]
     end
 
     def update(fields, params = {})
@@ -149,21 +150,6 @@ module RallyAPI
       end
       ret_val
     end
-
-    #def get_val(field)
-    #  return_val = rally_object[field]
-    #
-    #  if return_val.class == Hash
-    #    return RallyObject.new(@rally_rest, return_val)
-    #  end
-    #
-    #  if return_val.class == Array
-    #    make_object_array(field)
-    #    return_val = rally_object[field]
-    #  end
-    #
-    #  return_val
-    #end
 
     def get_val(field)
       return_val = @rally_object[field]

--- a/lib/rally_api/rally_query.rb
+++ b/lib/rally_api/rally_query.rb
@@ -1,5 +1,5 @@
 # :stopdoc:
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.

--- a/lib/rally_api/rally_query_result.rb
+++ b/lib/rally_api/rally_query_result.rb
@@ -1,5 +1,5 @@
 # :stopdoc:
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.

--- a/lib/rally_api/version.rb
+++ b/lib/rally_api/version.rb
@@ -1,8 +1,8 @@
 # :nodoc:
-#Copyright (c) 2002-2012 Rally Software Development Corp. All Rights Reserved.
+#Copyright (c) 2002-2015 Rally Software Development Corp. All Rights Reserved.
 #Your use of this Software is governed by the terms and conditions
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.
 module RallyAPI
-  VERSION = "1.1.2"
+  VERSION = "1.2.0"
 end

--- a/rally_api.gemspec
+++ b/rally_api.gemspec
@@ -5,8 +5,8 @@ require "rally_api/version"
 Gem::Specification.new do |s|
   s.name        = "rally_api"
   s.version     = RallyAPI::VERSION
-  s.authors     = ["Dave Smith", "Rylee Keys-DuMars"]
-  s.email       = ["dsmith@rallydev.com", "rylee@rallydev.com"]
+  s.authors     = ["Dave Smith", "Rylee Keys", "Kip Lehman"]
+  s.email       = ["dsmith@rallydev.com", "rylee@rallydev.com", "klehman@rallydev.com"]
   s.homepage    = "https://github.com/RallyTools/RallyRestToolkitForRuby"
   s.summary     = "A wrapper for the Rally Web Services API using json"
   s.description = "API wrapper for Rally's JSON REST web services api"
@@ -17,14 +17,15 @@ Gem::Specification.new do |s|
 
   s.has_rdoc = false
 
-  s.add_dependency('httpclient', '~> 2.4.0')
+  s.add_dependency('httpclient', '2.5.0')
+
   s.add_development_dependency('simplecov', '0.9.1')
-  s.add_development_dependency('rspec', '3.1.0')
-  s.add_development_dependency('rake', '10.3.2')
-  s.add_development_dependency('pry', '0.10.1')
+  s.add_development_dependency('rspec',     '3.1.0')
+  s.add_development_dependency('rake',      '10.3.2')
+  s.add_development_dependency('pry',       '0.10.1')
 
   #s.files         = `git ls-files`.split("\n")
-  s.files = %w(README.md Rakefile) + Dir.glob("{lib}/**/*.rb").delete_if { |item| item.include?(".svn") }
+  s.files = %w(README.md Rakefile) + Dir.glob("{lib}/**/*.rb")
   #s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   #s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]

--- a/spec/rally_api_create_spec.rb
+++ b/spec/rally_api_create_spec.rb
@@ -43,9 +43,7 @@ describe "Rally Json Create Tests" do
     else
       obj = {}
       obj["Name"] = "Test with a weblink"
-      obj[weblink_field_name] = {
-        "LinkID"=>"123", "DisplayString"=>"The Label"
-      }
+      obj[weblink_field_name] = { "LinkID"=>"123", "DisplayString"=>"The Label" }
       new_de = @rally.create(:defect, setup_test_defect(obj))
       expect(new_de.Name).to eq(obj["Name"])
       expect(new_de[weblink_field_name]["LinkID"]).to eq("123")

--- a/spec/rally_api_read_spec.rb
+++ b/spec/rally_api_read_spec.rb
@@ -50,8 +50,10 @@ describe "Rally Json Read Tests" do
       q.order = "Rank FooBar"
     end
     # TODO: Update to ensure an appropriate warning is generated in WSAPI 2.0
-    expect(defects.warnings.first).to match(/Please update your client to use the latest version of the API/)
-    expect(defects.warnings.length).to eq(1)
+    if @rally.wsapi_version != 'v2.0'
+      expect(defects.warnings.first).to match(/Please update your client to use the latest version of the API/)
+      expect(defects.warnings.length).to eq(1)
+    end
   end
 
   it "should conduct a find with an invalid order" do
@@ -69,8 +71,10 @@ describe "Rally Json Read Tests" do
       q.order = ""
     end
     # TODO: Update to ensure an appropriate warning is generated in WSAPI 2.0
-    expect(defects.warnings.first).to match(/Please update your client to use the latest version of the API/)
-    expect(defects.warnings.length).to eq(1)
+    if @rally.wsapi_version != 'v2.0'
+      expect(defects.warnings.first).to match(/Please update your client to use the latest version of the API/)
+      expect(defects.warnings.length).to eq(1)
+    end
     # Warning: No sort criteria has been defined.  The sort order will be unpredictable.
     # Between 10/10 and 10/21
   end


### PR DESCRIPTION
...rtindex, upped version to 1.2.0, noodled some tests to get them to pass, got rid of the .js on the end of urls for v2.0 usage, can now accommodate use of DisplayName for custom fields (internally prefix with the c_ sequence for create and update operations)