### PR TITLE
Might help performance.

### DIFF
--- a/lib/rally_api/rally_query.rb
+++ b/lib/rally_api/rally_query.rb
@@ -50,6 +50,7 @@ module RallyAPI
       query_params[:projectScopeDown] = @project_scope_down   unless @project_scope_down.nil?
       query_params[:order]            = @order                unless @order.nil?
       query_params[:pagesize]         = @page_size            unless @page_size.nil?
+      query_params[:limit]            = @limit                unless @limit.nil?
       query_params[:search]           = @search               unless @search.nil?
       query_params[:types]            = @types                unless @types.nil?
 
@@ -128,6 +129,9 @@ module RallyAPI
       @project_scope_down = query_hash[:project_scope_down]
       @project_scope_up   = query_hash[:project_scope_up]
       @order              = query_hash[:order]
+      if !query_hash[:pagesize].nil? && query_hash[:page_size].nil?
+        query_hash[:page_size] = query_hash[:pagesize]
+      end
       @page_size          = query_hash[:page_size]
       @limit              = query_hash[:limit]
       @workspace          = query_hash[:workspace]

--- a/lib/rally_api/version.rb
+++ b/lib/rally_api/version.rb
@@ -4,5 +4,5 @@
 #of the applicable Subscription Agreement between your company and
 #Rally Software Development Corp.
 module RallyAPI
-  VERSION = "1.2.0"
+  VERSION = "1.2.1"
 end


### PR DESCRIPTION
I noticed two things and fixed them (I hope):
1) The user specified ":limit" was not being passed to Rally.
2) Several pieces of code I found were using ":pagesize" (rather than ":page_size").
3) Incremented version from 1.2.0 to 1.2.1 to reflect these changes.