### PR TITLE
Update httpclient dependency to '>=2.8.3' to fix timeout error

### DIFF
--- a/rally_api.gemspec
+++ b/rally_api.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
   s.has_rdoc = false
 
-  s.add_dependency('httpclient', '2.6.0.1')
+  s.add_dependency('httpclient', '>=2.8.3')
 
   s.add_development_dependency('bundler',     '1.5.1')
   s.add_development_dependency('rake',        '10.3.2')


### PR DESCRIPTION
httpclient 2.6.0.1 throws this error:
`Object#timeout is deprecated, use Timeout.timeout instead.`

Latest version fixes that, and should fix the cert error that necessitated the explicit requirement for version 2.6.0.1.